### PR TITLE
Boot via hs-fs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ This is the base Nerves System configuration for the [TI AM62X](#sk-am62).
 | CPU            | 1.4 GHz quad-core Cortex-A53 (64-bit mode)                  |
 | Memory         | 2 GB DDR4                                                   |
 | Storage        | MicroSD and eMMC                                            |
-| Linux kernel   | 5.10                                                        |
+| Linux kernel   | 6.1                                                         |
 | IEx terminal   | UART `ttyS2`                                                |
 | GPIO, I2C, SPI | Yes - [Elixir Circuits](https://github.com/elixir-circuits) |
-| Display        | Yes, but not suppoerted yet                                 |
+| Display        | Yes, but not supported yet                                  |
 | ADC            | No                                                          |
 | Ethernet       | Yes                                                         |
 | WiFi           | Yes                                                         |
@@ -24,3 +24,13 @@ This is the base Nerves System configuration for the [TI AM62X](#sk-am62).
 | HW Watchdog    | Yes                                                         |
 
 [Image credit](#sk-am62): This image is from [ti.com](https://www.ti.com/tool/SK-AM62).
+
+## Dev Kits
+
+| Model | Status |
+| ----- | ------ |
+| [SK-AM62](https://www.ti.com/tool/SK-AM62) | Not supported |
+| [SK-AM62B](https://www.ti.com/tool/SK-AM62B) | Not supported |
+| [SK-AM62-LP](https://www.ti.com/tool/SK-AM62-LP) | Not supported |
+| [SK-AM62B-P1](https://www.ti.com/tool/SK-AM62B-P1) | In progress |
+| [SK-AM62-SIP](https://www.ti.com/tool/SK-AM62-SIP) | Pending |

--- a/package/ti-k3-r5-loader-next/ti-k3-r5-loader-next.mk
+++ b/package/ti-k3-r5-loader-next/ti-k3-r5-loader-next.mk
@@ -72,7 +72,7 @@ endef
 
 define TI_K3_R5_LOADER_NEXT_INSTALL_IMAGES_CMDS
 	cp $(@D)/tiboot3-*.bin $(BINARIES_DIR)/
-	cp $(@D)/tiboot3-am62x-gp-evm.bin $(BINARIES_DIR)/tiboot3.bin
+	cp $(@D)/tiboot3-am62x-hs-fs-evm.bin $(BINARIES_DIR)/tiboot3.bin
 endef
 
 $(eval $(kconfig-package))


### PR DESCRIPTION
Change the bootloader to use `hs-fs` instead of `gp` mode for the -P1 and -SIP dev kits. This means the Rev A dev kit will no longer work with this configuration.