### PR TITLE
Configure CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,44 @@
+exec: &exec
+  name: build-tools/nerves-system-br
+  version: 1.27.2
+  elixir: 1.16.3-otp-26
+
+version: 2.1
+
+orbs:
+  build-tools: nerves-project/build-tools@0.2.3
+
+workflows:
+  version: 2
+  build_test_deploy:
+    jobs:
+      - build-tools/get-br-dependencies:
+          exec:
+            <<: *exec
+          resource-class: small
+          context: nerves-build
+          download-site-url: http://dl.redwirelabs.com
+          filters:
+            tags:
+              only: /.*/
+      - build-tools/build-system:
+          exec:
+            <<: *exec
+          resource-class: xlarge
+          context: nerves-build
+          requires:
+            - build-tools/get-br-dependencies
+          filters:
+            tags:
+              only: /.*/
+      - build-tools/deploy-system:
+          exec:
+            <<: *exec
+          context: nerves-build
+          requires:
+            - build-tools/build-system
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /v.*/


### PR DESCRIPTION
Disabled CI on commit push to prevent excessive builds from running, since we don't use the artifact until a version is released. This was changed in the CircleCI project settings for this repo. A branch build will be run when a PR is opened, and the Nerves system artifact is stored in CI for download if needed. The branch build can be retriggered manually if necessary.

Used a `small` instance for `get-br-dependencies` because it's single-threaded and IO-bound on downloads. It was comparable in time to a medium instance but half the cost.

Increased `build-system` to an `xlarge` instance because it takes over an hour to compile on a `large`.